### PR TITLE
handle responses when one signature does not have a certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Please help adding IdP's or IdP services you find to work with Samlr. The below 
 
 * Novell/NetIQ
 * MS ADFS 2.0
+* Oracle WebLogic
 * http://simplesamlphp.org/
 * http://www.ssoeasy.com/
 * http://www.okta.com/

--- a/lib/samlr/response.rb
+++ b/lib/samlr/response.rb
@@ -19,7 +19,7 @@ module Samlr
     # is destructive the document needs to verify itself first, and then any signed assertions
     def verify!
       if signature.missing? && assertion.signature.missing?
-        raise Samlr::SignatureError.new("Neither response nor assertion signed")
+        raise Samlr::SignatureError.new("Neither response nor assertion signed with a certificate")
       end
 
       signature.verify! unless signature.missing?

--- a/lib/samlr/signature.rb
+++ b/lib/samlr/signature.rb
@@ -32,7 +32,7 @@ module Samlr
     end
 
     def missing?
-      signature.nil?
+      signature.nil? || certificate.nil?
     end
 
     def verify!
@@ -56,12 +56,12 @@ module Samlr
     private
 
     def x509
-      @x509 ||= certificate.x509
+      @x509 ||= certificate!.x509
     end
 
     # Establishes trust that the remote party is who you think
     def verify_fingerprint!
-      fingerprint.compare!(certificate.fingerprint)
+      fingerprint.compare!(certificate!.fingerprint)
     end
 
     # Tests that the document content has not been edited
@@ -117,9 +117,13 @@ module Samlr
         elsif cert = options[:certificate]
           Certificate.new(cert)
         else
-          raise SignatureError.new("No X509Certificate element in response signature. Cannot validate signature.")
+          nil
         end
       end
+    end
+
+    def certificate!
+      certificate || raise(SignatureError.new("No X509Certificate element in response signature. Cannot validate signature."))
     end
 
     def certificate_node

--- a/lib/samlr/tools/response_builder.rb
+++ b/lib/samlr/tools/response_builder.rb
@@ -95,9 +95,11 @@ module Samlr
 
         # The core response is ready, not on to signing
         response = builder.doc
+        assertion_options = options.merge(:skip_keyinfo => options[:skip_assertion_keyinfo])
+        response = sign(response, assertion_id, assertion_options) if sign_assertion
 
-        response = sign(response, assertion_id, options) if sign_assertion
-        response = sign(response, response_id, options)  if sign_response
+        response_options = options.merge(:skip_keyinfo => options[:skip_response_keyinfo])
+        response = sign(response, response_id, response_options)  if sign_response
 
         response.to_xml(COMPACT)
       end

--- a/test/unit/test_response_scenarios.rb
+++ b/test/unit/test_response_scenarios.rb
@@ -71,7 +71,7 @@ describe Samlr do
   end
 
   describe "when there is no keyinfo" do
-    subject { saml_response(:certificate => TEST_CERTIFICATE, :skip_keyinfo => true) }
+    subject { saml_response(:certificate => TEST_CERTIFICATE, :skip_response_keyinfo => true, :skip_assertion_keyinfo => true) }
 
     it "fails" do
       assert_raises(Samlr::SignatureError) { subject.verify! }
@@ -108,4 +108,19 @@ describe Samlr do
     end
   end
 
+  describe "when only the response signature is missing a certificate" do
+    subject { saml_response(:certificate => TEST_CERTIFICATE, :skip_response_keyinfo => true) }
+
+    it "verifies" do
+      assert subject.verify!
+    end
+  end
+
+  describe "when only the assertion signature is missing a certificate" do
+    subject { saml_response(:certificate => TEST_CERTIFICATE, :skip_assertion_keyinfo => true) }
+
+    it "verifies" do
+      assert subject.verify!
+    end
+  end
 end

--- a/test/unit/test_signature.rb
+++ b/test/unit/test_signature.rb
@@ -21,15 +21,15 @@ describe Samlr::Signature do
     end
   end
 
-  describe "#certificate" do
+  describe "#certificate!" do
     it "should extract the certificate" do
-      assert_equal TEST_CERTIFICATE.to_certificate, @signature.send(:certificate)
+      assert_equal TEST_CERTIFICATE.to_certificate, @signature.send(:certificate!)
     end
 
     describe "when there is no X509 certificate" do
       it "should raise a signature error" do
         @signature.stub(:certificate_node, nil) do
-          assert_raises(Samlr::SignatureError) { @signature.send(:certificate) }
+          assert_raises(Samlr::SignatureError) { @signature.send(:certificate!) }
         end
       end
     end


### PR DESCRIPTION
Weblogic signs both the response and the assertion but only includes the certificate on the assertion. 

/cc @zendesk/secdev @zendesk/octo 