### PR TITLE
remove trollop and unintuitive / random option shorthands

### DIFF
--- a/bin/samlr
+++ b/bin/samlr
@@ -1,19 +1,21 @@
 #!/usr/bin/env ruby
 
 require "samlr"
+require "samlr/version"
 require "samlr/command"
 
-require "trollop"
+require "optparse"
 
 ARGV << "--help" if ARGV.empty?
 
-opts = Trollop.options do
-  banner <<-EOS
+options = {}
+OptionParser.new do |opt|
+  opt.banner = <<-EOS
 SAML response command line tool.
 
 Usage examples:
   samlr --verify --fingerprint ab:23:cd --skip-conditions <response.xml|directory of responses>
-  samlr --verify --certificate <x509_certificate.crt> --skip-conditions <response.xml|directory of responses> 
+  samlr --verify --certificate <x509_certificate.crt> --skip-conditions <response.xml|directory of responses>
   samlr --verify --skip-fingerprint --skip-conditions <response.xml|directory of responses>
   samlr --schema-validate response.xml
   samlr --print response.xml[.base64]
@@ -25,22 +27,24 @@ Try it with the gem examples:
 Full list of options:
 EOS
 
-  opt :verify, "Verify a SAML response document"
-  opt :fingerprint, "The fingerprint to verify the certificate against", :type => String
-  opt :certificate, "A certificate (PEM or DER) to validate the signature against (assuming no certificate embedded in the response)", :type => IO
-  opt :skip_conditions, "Skip conditions check"
-  opt :skip_validation, "Skip schema validation rejection"
-  opt :skip_fingerprint, "Skip certificate fingerprint check"
-  opt :verbose, "Log to STDOUT"
-  opt :schema_validate, "Perform a schema validation against the input"
-  opt :print, "Pretty prints the XML"
-end
+  opt.on("-v", "--verify", "Verify a SAML response document") { options[:verify] = true }
+  opt.on("-f", "--fingerprint FINGERPRINT", "The fingerprint to verify the certificate against") { |c| options[:fingerprint] = c }
+  opt.on("-c", "--certificate FILE", "A certificate (PEM or DER) to validate the signature against (assuming no certificate embedded in the response)") { |c| options[:certificate] = File.open(c) }
+  opt.on("--skip-conditions", "Skip conditions check") { options[:skip_conditions] = true }
+  opt.on("--skip-validation", "Skip schema validation rejection") { options[:skip_validation] = true }
+  opt.on("--skip-fingerprint", "Skip certificate fingerprint check") { options[:skip_fingerprint] = true }
+  opt.on("--verbose", "Log to STDOUT") { options[:verbose] = true }
+  opt.on("--schema-validate", "Perform a schema validation against the input") { options[:schema_validate] = true }
+  opt.on("--print", "Pretty prints the XML") { options[:print] = true }
+  opt.on("-h", "--help", "Show this.") { puts opt; exit }
+  opt.on("--version", "Show Version"){ puts Samlr::VERSION; exit}
+end.parse!
 
 if ARGV.empty? || !File.exist?(ARGV[0])
   puts "Input file not given or does not exist"
   exit 1
 end
 
-opts[:certificate] &&= opts[:certificate].read
+options[:certificate] &&= options[:certificate].read
 
-puts Samlr::Command.execute(opts, ARGV[0])
+puts Samlr::Command.execute(options, ARGV[0])

--- a/lib/samlr/version.rb
+++ b/lib/samlr/version.rb
@@ -1,0 +1,3 @@
+module Samlr
+  VERSION = "2.1.0"
+end

--- a/samlr.gemspec
+++ b/samlr.gemspec
@@ -1,4 +1,6 @@
-Gem::Specification.new "samlr", "2.1.0" do |s|
+require './lib/samlr/version'
+
+Gem::Specification.new "samlr", Samlr::VERSION do |s|
   s.summary     = "Ruby tools for SAML"
   s.description = "Helps you implement a SAML SP"
   s.authors     = ["Morten Primdahl"]
@@ -11,7 +13,6 @@ Gem::Specification.new "samlr", "2.1.0" do |s|
 
   s.add_runtime_dependency("nokogiri", ">= 1.5.5")
   s.add_runtime_dependency("uuidtools", ">= 2.1.3")
-  s.add_runtime_dependency("trollop", ">= 1.16.2")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("bundler")

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,32 @@
+require_relative "test_helper"
+
+describe "CLI" do
+  def sh(command, options={})
+    result = Bundler.with_clean_env { `#{command}` }
+    raise "#{options[:fail] ? "SUCCESS" : "FAIL"} #{command}\n#{result}" if $?.success? == !!options[:fail]
+    result
+  end
+
+  def samlr(arguments, options={})
+    sh("ruby -Ilib -r bundler/setup ./bin/samlr #{arguments}", options)
+  end
+
+  it "shows help without arguments" do
+    out = samlr("")
+    out.must_include "SAML response command line tool."
+  end
+
+  it "shows help with -h" do
+    out = samlr("-h")
+    out.must_include "SAML response command line tool."
+  end
+
+  it "shows version with --version" do
+    out = samlr("--version")
+    out.must_equal "#{Samlr::VERSION}\n"
+  end
+
+  it "fails with argument" do
+    samlr("xxxx", fail: true)
+  end
+end


### PR DESCRIPTION
@steved @morten @kintner 

also adding `--version`

before:
```
./bin/samlr --help
SAML response command line tool.

Usage examples:
  samlr --verify --fingerprint ab:23:cd --skip-conditions <response.xml|directory of responses>
  samlr --verify --certificate <x509_certificate.crt> --skip-conditions <response.xml|directory of responses>
  samlr --verify --skip-fingerprint --skip-conditions <response.xml|directory of responses>
  samlr --schema-validate response.xml
  samlr --print response.xml[.base64]

Try it with the gem examples:
  ruby -Ilib bin/samlr -v -s -f 44:D2:9D:98:49:66:27:30:3A:67:A2:5D:97:62:31:65:57:9F:57:D1
test/fixtures/sample_response.xml
  ruby -Ilib bin/samlr -v -s -c test/fixtures/default_samlr_certificate.pem
test/fixtures/no_cert_response.xml

Full list of options:
  -v, --verify                        Verify a SAML response document
  -f, --fingerprint=<s>               The fingerprint to verify the certificate against
  -c, --certificate=<filename/uri>    A certificate (PEM or DER) to validate the signature against (assuming no
                                      certificate embedded in the response)
  -s, --skip-conditions               Skip conditions check
  -k, --skip-validation               Skip schema validation rejection
  -i, --skip-fingerprint              Skip certificate fingerprint check
  -e, --verbose                       Log to STDOUT
  -h, --schema-validate               Perform a schema validation against the input
  -p, --print                         Pretty prints the XML
  -l, --help                          Show this message
```

after:
```
./bin/samlr --help
SAML response command line tool.

Usage examples:
  samlr --verify --fingerprint ab:23:cd --skip-conditions <response.xml|directory of responses>
  samlr --verify --certificate <x509_certificate.crt> --skip-conditions <response.xml|directory of responses>
  samlr --verify --skip-fingerprint --skip-conditions <response.xml|directory of responses>
  samlr --schema-validate response.xml
  samlr --print response.xml[.base64]

Try it with the gem examples:
  ruby -Ilib bin/samlr -v -s -f 44:D2:9D:98:49:66:27:30:3A:67:A2:5D:97:62:31:65:57:9F:57:D1 test/fixtures/sample_response.xml
  ruby -Ilib bin/samlr -v -s -c test/fixtures/default_samlr_certificate.pem                 test/fixtures/no_cert_response.xml

Full list of options:
    -v, --verify                     Verify a SAML response document
    -f, --fingerprint FINGERPRINT    The fingerprint to verify the certificate against
    -c, --certificate FILE           A certificate (PEM or DER) to validate the signature against (assuming no certificate embedded in the response)
        --skip-conditions            Skip conditions check
        --skip-validation            Skip schema validation rejection
        --skip-fingerprint           Skip certificate fingerprint check
        --verbose                    Log to STDOUT
        --schema-validate            Perform a schema validation against the input
        --print                      Pretty prints the XML
    -h, --help                       Show this.
        --version                    Show Version
```

### Risks
 - None