### PR TITLE
support multiple audience conditions

### DIFF
--- a/lib/samlr/condition.rb
+++ b/lib/samlr/condition.rb
@@ -34,8 +34,10 @@ module Samlr
     end
 
     def audience_satisfied?
-      audience.nil? || options[:audience].nil? ||
-        options[:audience] === audience
+      options[:audience].nil? ||
+      audience.nil?           ||
+      audience.empty?         ||
+      audience.any? { |a| options[:audience] === a }
     end
 
     private
@@ -43,11 +45,13 @@ module Samlr
     def extract_audience(condition)
       return unless condition
 
-      audience_node = condition.at("./saml:AudienceRestriction/saml:Audience", NS_MAP)
+      audience_restriction_node = condition.at('./saml:AudienceRestriction', NS_MAP)
+      return unless audience_restriction_node
 
-      return unless audience_node
+      audience_nodes = audience_restriction_node.search('./saml:Audience', NS_MAP)
+      return unless audience_nodes.any?
 
-      audience_node.text
+      audience_nodes.map(&:text)
     end
   end
 end

--- a/lib/samlr/tools/response_builder.rb
+++ b/lib/samlr/tools/response_builder.rb
@@ -64,8 +64,12 @@ module Samlr
 
                 unless skip_conditions
                   xml["saml"].Conditions("NotBefore" => not_before, "NotOnOrAfter" => not_on_or_after) do
-                    xml["saml"].AudienceRestriction do
-                      xml["saml"].Audience(audience)
+                    Array(audience).each do |audience_nodes|
+                      xml["saml"].AudienceRestriction do
+                        Array(audience_nodes).each do |audience_value|
+                          xml["saml"].Audience(audience_value)
+                        end
+                      end
                     end
                   end
                 end


### PR DESCRIPTION
@zendesk/secdev @grosser 

Currently we only check the the first `<AudienceRestriction>` node and the first `<Audience>` child when applying the audience restriction. This adds supports for multiple  `<Audience>` nodes under a single `<AudienceRestriction>` parent. 

## SAML Spec:

> ##### [2.5.1.4 Elements `<AudienceRestriction>` and `<Audience>`](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)
> 
> The <AudienceRestriction> element specifies that the assertion is addressed to one or more specific audiences identified by <Audience> elements. Although a SAML relying party that is outside the audiences specified is capable of drawing conclusions from an assertion, the SAML asserting party explicitly makes no representation as to accuracy or trustworthiness to such a party. It contains the following element:
> 
> `<Audience>`
> 
> A URI reference that identifies an intended audience. The URI reference MAY identify a document that describes the terms and conditions of audience membership. It MAY also contain the unique identifier URI from a SAML name identifier that describes a system entity (see Section 8.3.6).
> 
> **The audience restriction condition evaluates to Valid if and only if the SAML relying party is a member of one or more of the audiences specified.**