### PR TITLE
support ruby 2.1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.1.10
+  - 2.1.9
   - 2.2.6
   - 2.3.3
 branches:

--- a/samlr.gemspec
+++ b/samlr.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "samlr", Samlr::VERSION do |s|
   s.files       = `git ls-files lib bin config README.md LICENSE`.split("\n")
   s.license     = "Apache License Version 2.0"
 
-  s.required_ruby_version = '>= 2.1.10'
+  s.required_ruby_version = '>= 2.1.9'
 
   s.add_runtime_dependency("nokogiri", ">= 1.5.5")
   s.add_runtime_dependency("uuidtools", ">= 2.1.3")


### PR DESCRIPTION
@zendesk/secdev 🐙 

#22 raised the required ruby version to ruby 2.1.10. That's unnecessary since ruby 2.1.9 is identical to ruby 2.1.10

https://www.ruby-lang.org/en/news/2016/04/01/ruby-2-1-10-released/

