### PR TITLE
Invalid saml requests will no longet cause exceptions

### DIFF
--- a/lib/samlr/tools.rb
+++ b/lib/samlr/tools.rb
@@ -114,6 +114,7 @@ module Samlr
       return unless data
       decoded = Base64.decode64(data)
       decoded = self.inflate(decoded) if compressed
+      return unless decoded
       begin
         doc = Nokogiri::XML(decoded) { |config| config.strict }
       rescue Nokogiri::XML::SyntaxError => e
@@ -136,10 +137,11 @@ module Samlr
     def self.inflate(data)
       inflater  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       decoded = inflater.inflate(data)
-
       inflater.finish
       inflater.close
       decoded
+    rescue Zlib::BufError, Zlib::DataError
+      nil
     end
   end
 end

--- a/test/unit/test_request.rb
+++ b/test/unit/test_request.rb
@@ -45,8 +45,12 @@ describe Samlr::Request do
       assert_instance_of Nokogiri::XML::Document, Samlr::Request.parse(document)
     end
 
-    it "fails when given an invalid string" do
-      assert_raises(Samlr::FormatError) { Samlr::Request.parse(deflate("hello")) }
+    it "returns nill when given an invalid string" do
+      assert_nil Samlr::Request.parse("broken")
+    end
+
+    it 'returns nill when given empty string' do
+      assert_nil Samlr::Request.parse("")
     end
 
     it "constructs and XML document when given a Base64 encoded response" do


### PR DESCRIPTION
@zendesk/secdev

#### Description
Invalid Logout Requests would throw exceptions, fixed so that it responds with nil now

#### Risk
None: Just added a layer of protection where Exceptions were being thrown