### PR TITLE
Changed attributes hash to store keys by string and not also by symbols

### DIFF
--- a/lib/samlr/assertion.rb
+++ b/lib/samlr/assertion.rb
@@ -42,7 +42,7 @@ module Samlr
             value = values.map { |value| value.text }
           end
 
-          attrs[name] = attrs[name.to_sym] = value
+          attrs[name] = value
         end
       end
     end

--- a/test/unit/test_assertion.rb
+++ b/test/unit/test_assertion.rb
@@ -13,7 +13,6 @@ describe Samlr::Assertion do
 
   describe "#attributes" do
     it "returns a hash of assertion attributes" do
-      assert_equal subject.attributes[:tags], "mean horse"
       assert_equal subject.attributes["tags"], "mean horse"
     end
 


### PR DESCRIPTION
@zendesk/secdev 🐙 @grosser 

Changes the `response.assertion.attributes` method to return a hash that only contains String keys instead of duplicating them as symbols. This simplifies iterating over the hash.