### PR TITLE
Assertion#attributes modified to include nil attributes

### DIFF
--- a/lib/samlr/assertion.rb
+++ b/lib/samlr/assertion.rb
@@ -35,7 +35,7 @@ module Samlr
           values = statement.xpath("./saml:AttributeValue", NS_MAP)
 
           if values.size == 0
-            next
+            value = nil
           elsif values.size == 1
             value = values.first.text
           else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,7 +54,7 @@ def fixed_saml_response(options = {})
     :response_id     => "samlr123",
     :assertion_id    => "samlr456",
     :in_response_to  => "samlr789",
-    :attributes      => { "tags" => "mean horse", "things" => [ "one", "two", "three" ] },
+    :attributes      => { "tags" => "mean horse", "things" => [ "one", "two", "three" ], "integer" => nil, "text" => "" },
     :not_on_or_after => Samlr::Tools::Timestamp.stamp(Time.at(1344379365 + 60)),
     :not_before      => Samlr::Tools::Timestamp.stamp(Time.at(1344379365 - 60))
   }.merge(options)

--- a/test/unit/test_assertion.rb
+++ b/test/unit/test_assertion.rb
@@ -16,6 +16,16 @@ describe Samlr::Assertion do
       assert_equal subject.attributes["tags"], "mean horse"
     end
 
+    it "includes attributes that are nil" do
+      assert_includes subject.attributes.keys, "integer"
+      assert_nil subject.attributes["integer"]
+    end
+
+    it "includes blank attributes" do
+      assert_includes subject.attributes.keys, "text"
+      assert_equal "", subject.attributes["text"]
+    end
+
     it "turns multiple attribute values into an array" do
       assert_equal subject.attributes["things"].sort, [ "one", "two", "three" ].sort
     end

--- a/test/unit/test_reference.rb
+++ b/test/unit/test_reference.rb
@@ -20,7 +20,7 @@ describe Samlr::Reference do
 
   describe "#digest_value" do
     it "should return the verbatim value" do
-      assert_equal "OSVXSTu8W+eGao6muxUHXcKQwZU=", @reference.digest_value
+      assert_equal "05/ZoKG4L2PiMssuD+msQ9BBl9A=", @reference.digest_value
     end
   end
 


### PR DESCRIPTION
@zendesk/secdev 🐙 @grosser @morten 

Currently, Assertion#attributes skips over nil attributes. This prevents an IdP from clearing out an existing attribute.

Assertion#attributes has always skipped over nil attributes: a5876622254d35c8d3872c6852c8d1289b0f4f26