### PR TITLE
Use UUID.random_create to generate UUID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 .rbenv-version
 pkg/
+.idea

--- a/lib/samlr/tools.rb
+++ b/lib/samlr/tools.rb
@@ -46,7 +46,7 @@ module Samlr
 
     # Generate an xs:NCName conforming UUID
     def self.uuid
-      "samlr-#{UUIDTools::UUID.timestamp_create}"
+      "samlr-#{UUIDTools::UUID.random_create}"
     end
 
     # Deflates, Base64 encodes and CGI escapes a string

--- a/test/unit/test_response.rb
+++ b/test/unit/test_response.rb
@@ -44,9 +44,10 @@ describe Samlr::Response do
       modified_document.xpath("/samlp:Response/samlp:Extensions/saml:Assertion/ds:Signature", Samlr::NS_MAP).remove
       modified_document.xpath("/samlp:Response/saml:Assertion/saml:Subject/saml:NameID", Samlr::NS_MAP).first.content="evil@example.org"
       modified_document.xpath("/samlp:Response/saml:Assertion", Samlr::NS_MAP).first["ID"] = "evil_id"
-
-      response = Samlr::Response.new(modified_document.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML), {:certificate => TEST_CERTIFICATE.x509})
-      assert_raises(Samlr::FormatError) { response.verify! }
+      assert_raises(Samlr::FormatError) do
+        response = Samlr::Response.new(modified_document.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML), {:certificate => TEST_CERTIFICATE.x509})
+        response.verify!
+      end
     end
   end
 


### PR DESCRIPTION
`UUID.timestamp_create` makes a call to `ipconfig` or `ifconfig` (depending on the OS architecture its running on) in order to retrieve the mac address which it then uses, in part, to generate a UUID. This creates a system-level dependency which may be undesired if running in a containerized environment where such binaries might not be available out of the box.

This PR removes that system-level dependency by using `UUID.random_create` instead; this method is used in numerous other places and maintains a high level of entropy.

Additionally, the exception thrown by the `XSW attack` was getting thrown before the `assert_raises` statement causing the test suite to fail so it was fixed as well.