### PR TITLE
Test with newer versions of Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
+          - "4.0"
     steps:
-      - uses: zendesk/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
-          - "3.0"
-          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source "http://rubygems.org"
 
-gem 'byebug', platforms: (RUBY_VERSION > "2.0.0" ? :mri : :mingw)
-
 gemspec
+
+gem "bump"
+gem "byebug", platforms: :mri
+gem "minitest", "~> 6"
+gem "minitest-mock"
+gem "rake"

--- a/samlr.gemspec
+++ b/samlr.gemspec
@@ -9,18 +9,13 @@ Gem::Specification.new "samlr", Samlr::VERSION do |s|
   s.files       = `git ls-files lib bin config README.md LICENSE`.split("\n")
   s.license     = "Apache License Version 2.0"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.2"
 
   s.add_dependency("base64")
   s.add_dependency("cgi")
   s.add_dependency("logger")
   s.add_dependency("nokogiri", ">= 1.5.5")
   s.add_dependency("uuidtools", ">= 2.1.3")
-
-  s.add_development_dependency("rake")
-  s.add_development_dependency("bundler")
-  s.add_development_dependency("minitest", "~> 5")
-  s.add_development_dependency("bump")
 
   s.executables << "samlr"
 end

--- a/samlr.gemspec
+++ b/samlr.gemspec
@@ -11,12 +11,15 @@ Gem::Specification.new "samlr", Samlr::VERSION do |s|
 
   s.required_ruby_version = ">= 2.7"
 
-  s.add_runtime_dependency("nokogiri", ">= 1.5.5")
-  s.add_runtime_dependency("uuidtools", ">= 2.1.3")
+  s.add_dependency("base64")
+  s.add_dependency("cgi")
+  s.add_dependency("logger")
+  s.add_dependency("nokogiri", ">= 1.5.5")
+  s.add_dependency("uuidtools", ">= 2.1.3")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("bundler")
-  s.add_development_dependency("minitest")
+  s.add_development_dependency("minitest", "~> 5")
   s.add_development_dependency("bump")
 
   s.executables << "samlr"

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -23,7 +23,7 @@ describe "CLI" do
 
   it "shows version with --version" do
     out = samlr("--version")
-    assert_match /^#{Regexp.escape(Samlr::VERSION)}$/, out
+    assert_match(/^#{Regexp.escape(Samlr::VERSION)}$/, out)
   end
 
   it "fails with argument" do

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 
 describe "CLI" do
   def sh(command, options={})
-    result = Bundler.with_clean_env { `#{command}` }
+    result = Bundler.with_unbundled_env { `#{command}` }
     raise "#{options[:fail] ? "SUCCESS" : "FAIL"} #{command}\n#{result}" if $?.success? == !!options[:fail]
     result
   end
@@ -13,17 +13,17 @@ describe "CLI" do
 
   it "shows help without arguments" do
     out = samlr("")
-    out.must_include "SAML response command line tool."
+    assert_includes out, "SAML response command line tool."
   end
 
   it "shows help with -h" do
     out = samlr("-h")
-    out.must_include "SAML response command line tool."
+    assert_includes out, "SAML response command line tool."
   end
 
   it "shows version with --version" do
     out = samlr("--version")
-    out.must_equal "#{Samlr::VERSION}\n"
+    assert_match /^#{Regexp.escape(Samlr::VERSION)}$/, out
   end
 
   it "fails with argument" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "minitest/autorun"
+require "minitest/mock"
 
 require "time"
 require "base64"

--- a/test/unit/test_condition.rb
+++ b/test/unit/test_condition.rb
@@ -37,7 +37,7 @@ describe Samlr::Condition do
             verify!
             flunk "Expected exception"
           rescue Samlr::ConditionsError => e
-            assert_match /Audience/, e.message
+            assert_match(/Audience/, e.message)
           end
         end
       end
@@ -132,7 +132,7 @@ describe Samlr::Condition do
               verify!
               flunk "Expected exception"
             rescue Samlr::ConditionsError => e
-              assert_match /Audience/, e.message
+              assert_match(/Audience/, e.message)
             end
           end
         end
@@ -151,7 +151,7 @@ describe Samlr::Condition do
           subject.verify!
           flunk "Expected exception"
         rescue Samlr::ConditionsError => e
-          assert_match /Not before/, e.message
+          assert_match(/Not before/, e.message)
         end
       end
     end
@@ -168,7 +168,7 @@ describe Samlr::Condition do
           subject.verify!
           flunk "Expected exception"
         rescue Samlr::ConditionsError => e
-          assert_match /Not on or after/, e.message
+          assert_match(/Not on or after/, e.message)
         end
       end
     end

--- a/test/unit/test_logout_request.rb
+++ b/test/unit/test_logout_request.rb
@@ -65,21 +65,21 @@ describe Samlr::LogoutRequest do
       options.merge!(:name_id_options => {:format => "some format"})
       request = Samlr::LogoutRequest.new(nil, options)
 
-      assert_match /<saml:NameID Format="some format">/, request.body
+      assert_match(/<saml:NameID Format="some format">/, request.body)
     end
 
     it "understands NameQualifier" do
       options.merge!(:name_id_options => {:name_qualifier => "Some name qualifier"})
       request = Samlr::LogoutRequest.new(nil, options)
 
-      assert_match /NameQualifier="Some name qualifier"/, request.body
+      assert_match(/NameQualifier="Some name qualifier"/, request.body)
     end
 
     it "understands SPNameQualifier" do
       options.merge!(:name_id_options => {:spname_qualifier => "Some SPName qualifier"})
       request = Samlr::LogoutRequest.new(nil, options)
 
-      assert_match /SPNameQualifier="Some SPName qualifier"/, request.body
+      assert_match(/SPNameQualifier="Some SPName qualifier"/, request.body)
     end
   end
 

--- a/test/unit/test_logout_request.rb
+++ b/test/unit/test_logout_request.rb
@@ -57,8 +57,8 @@ describe Samlr::LogoutRequest do
         request.body
       end
 
-      body.must_include '<saml:NameID Format="some format">'
-      stderr.must_equal "[DEPRECATION] options[:name_id_format] is deprecated. Please use options[:name_id_options][:format] instead\n"
+      assert_includes body, '<saml:NameID Format="some format">'
+      assert_equal "[DEPRECATION] options[:name_id_format] is deprecated. Please use options[:name_id_options][:format] instead\n", stderr
     end
 
     it "understands [:name_id_options][:format]" do

--- a/test/unit/test_response.rb
+++ b/test/unit/test_response.rb
@@ -85,12 +85,12 @@ describe Samlr::Response do
       let(:saml_resp) { Samlr::Response.new(saml_response_doc, fingerprint: Samlr::FingerprintSHA256.x509(TEST_CERTIFICATE.x509)) }
 
       it "validates the saml response" do
-        assert_match /user@user.com<!---->.evil.com/, saml_response_doc
+        assert_match(/user@user.com<!---->.evil.com/, saml_response_doc)
         assert saml_resp.verify!
       end
 
       it "ignores the comment and parses the name_id XML node correctly" do
-        assert_match /user@user.com<!---->.evil.com/, saml_response_doc
+        assert_match(/user@user.com<!---->.evil.com/, saml_response_doc)
         assert_equal "user@user.com.evil.com", saml_resp.name_id
       end
     end

--- a/test/unit/tools/test_response_builder.rb
+++ b/test/unit/tools/test_response_builder.rb
@@ -18,7 +18,7 @@ describe Samlr::Tools::ResponseBuilder do
 
     it "doesn't include the name_id when nil" do
       result = saml_response_document(:certificate => @certificate, :name_id => nil)
-      refute_match /nameid/i, result
+      refute_match(/nameid/i, result)
     end
   end
 end


### PR DESCRIPTION
Drop support for Ruby 3.1 and below, and start test with Ruby 3.4 and 4.0.